### PR TITLE
hero block added

### DIFF
--- a/blocks/hero/block.js
+++ b/blocks/hero/block.js
@@ -1,0 +1,162 @@
+/**
+ * CAGov hero
+ *
+ * Simple block, renders and saves the same content without interactivity.
+ *
+ * Using inline styles - no external stylesheet needed.  Not recommended
+ * because all of these styles will appear in `post_content`.
+ */
+ ( function( blocks, editor, i18n, element, components, _ ) {
+	var __ = i18n.__;
+	var el = element.createElement;
+	var RichText = editor.RichText;
+	var MediaUpload = editor.MediaUpload;
+
+	blocks.registerBlockType( 'cagov/hero', {
+		title: __( 'CAGov: hero', 'cagov-design-system' ),
+		category: 'layout',
+		attributes: {
+			title: {
+				type: 'array',
+				source: 'children',
+				selector: 'h3',
+			},
+			body: {
+				type: 'array',
+				source: 'children',
+				selector: 'p',
+			},
+			buttontext: {
+				type: 'array',
+				source: 'children',
+				selector: 'a',
+			},
+			mediaID: {
+				type: 'number',
+			},
+			mediaURL: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'img',
+				attribute: 'src',
+			}
+		},
+		example: {
+			attributes: {
+				title: __( 'hero title', 'cagov-design-system' ),
+				body: __( 'hero body', 'cagov-design-system' ),
+				buttontext: __( 'hero button text', 'cagov-design-system' ),
+				mediaURL: 'http://www.fillmurray.com/720/240',
+			}
+		},
+		edit: function( props ) {
+			var attributes = props.attributes;
+			var onSelectImage = function( media ) {
+				return props.setAttributes( {
+					mediaURL: media.url,
+					mediaID: media.id,
+				} );
+			};
+			return el('div', { className: 'cagov-with-sidebar cagov-with-sidebar-left cagov-featured-section cagov-border' },
+				el('div', {},
+					el('div', { className: 'cagov-stack cagov-p-2 cagov-featured-sidebar' },
+						el( RichText, {
+							tagName: 'h3',
+							inline: true,
+							placeholder: __(
+								'Write hero title…',
+								'cagov-design-system'
+							),
+							value: attributes.title,
+							onChange: function( value ) {
+								props.setAttributes( { title: value } );
+							},
+						} ),
+						el( RichText, {
+							tagName: 'p',
+							inline: true,
+							placeholder: __(
+								'Write hero body',
+								'cagov-design-system'
+							),
+							value: attributes.body,
+							onChange: function( value ) {
+								props.setAttributes( { body: value } );
+							},
+						} ),
+						el( RichText, {
+							tagName: 'a',
+							className: 'cagov-action-link',
+							inline: true,
+							placeholder: __(
+								'Write button text',
+								'cagov-design-system'
+							),
+							value: attributes.buttontext,
+							onChange: function( value ) {
+								props.setAttributes( { buttontext: value } );
+							},
+						} )
+					),
+					el('div', {  },
+						el( MediaUpload, {
+							onSelect: onSelectImage,
+							allowedTypes: 'image',
+							value: attributes.mediaID,
+							render: function( obj ) {
+								return el(
+									components.Button,
+									{
+										className: attributes.mediaID
+											? 'image-button'
+											: 'button button-large',
+										onClick: obj.open,
+									},
+									! attributes.mediaID
+										? __( 'Upload Image', 'cagov-design-system' )
+										: el( 'img', { src: attributes.mediaURL, className: 'cagov-featured-image', } )
+								);
+							},
+						} )
+						/*el('img', { className: 'cagov-featured-image', src: 'http://www.fillmurray.com/720/240' },
+						),*/
+					),
+				),
+			);
+		},
+		save: function(props) {
+			var attributes = props.attributes;
+			return el('div', { className: 'cagov-with-sidebar cagov-with-sidebar-left cagov-featured-section cagov-border' },
+				el('div', {},
+					el('div', { className: 'cagov-stack cagov-p-2 cagov-featured-sidebar' },
+						{ className: 'cagov-hero cagov-stack' },
+						el( RichText.Content, {
+							tagName: 'h3',
+							value: attributes.title,
+						} ),
+						el( RichText.Content, {
+							tagName: 'p',
+							value: attributes.body,
+						} ),
+						el( RichText.Content, {
+							tagName: 'a',
+							className: 'cagov-action-link',
+							value: attributes.buttontext,
+						} )
+					),
+					attributes.mediaURL && el('div', {  },
+						el('img', { className: 'cagov-featured-image', src: attributes.mediaURL  },
+						),
+					),
+				),
+			);
+		},
+	} );
+} )(
+	window.wp.blocks,
+	window.wp.editor,
+	window.wp.i18n,
+	window.wp.element,
+	window.wp.components,
+	window._
+);

--- a/blocks/hero/plugin.php
+++ b/blocks/hero/plugin.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Plugin Name: Hero
+ * Plugin URI: TBD
+ * Description: TBD
+ * Version: 1.1.0
+ * Author: California Office of Digital Innovation
+ * @package cagov-design-system
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Load all translations for our plugin from the MO file.
+ */
+add_action( 'init', 'cagov_design_system_gutenberg_block_hero' );
+
+function cagov_design_system_gutenberg_block_hero() {
+	load_plugin_textdomain( 'cagov-design-system', false, basename( __DIR__ ) . '/languages' );
+}
+
+/**
+ * Registers all block assets so that they can be enqueued through Gutenberg in
+ * the corresponding context.
+ *
+ * Passes translations to JavaScript.
+ */
+function cagov_design_system_register_hero() {
+
+	if ( ! function_exists( 'register_block_type' ) ) {
+		// Gutenberg is not active.
+		return;
+	}
+
+	wp_register_script(
+		'california-design-system-hero-block',
+		plugins_url( 'block.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'underscore' ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
+	);
+
+	wp_register_style(
+		'california-design-system-hero-style',
+		plugins_url( 'style.css', __FILE__ ),
+		array( ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'style.css' )
+	);
+
+	register_block_type( 'cagov/hero', array(
+		'style' => 'california-design-system-hero-style',
+		'editor_script' => 'california-design-system-hero-block',
+	) );
+
+}
+add_action( 'init', 'cagov_design_system_register_hero' );

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -1,0 +1,69 @@
+.stack * + * {
+  margin-top: 1.5rem;
+}
+.cagov-p-2 {
+  padding: 2rem;
+}
+.cagov-border {
+  border: solid 1px;
+}
+
+/* homepage specific rules */
+.cagov-featured-sidebar {
+  max-width: 360px;
+}
+.cagov-featured-section {
+  max-height: 360px;
+}
+.cagov-featured-image {
+  object-fit: cover;
+  width: 100%;
+  display: block;
+  height: 100%;
+}
+/* editor overrides */
+.editor-styles-wrapper img.cagov-featured-image, .block-editor__container img.cagov-featured-image {
+  height: 100%;
+}
+.editor-styles-wrapper .wp-block a.cagov-action-link {
+  color: #fff;
+}
+.cagov-featured-section .components-button.image-button {
+  display: block;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+a.cagov-action-link {
+  background-color: #33705B;
+  color: white;
+  padding: 1rem;
+  border-radius: .3rem;
+  font-weight: bold;
+  display: inline-block;
+}
+
+/* sidebar layout */
+.cagov-with-sidebar {
+  overflow: hidden;
+}
+.cagov-with-sidebar > * {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+}
+.cagov-with-sidebar > * > * {
+  margin: 0;
+  flex-grow: 1;
+}
+.cagov-with-sidebar-left > * > :last-child {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-width: calc(30% - var(0px));
+}
+.cagov-with-sidebar-right > * > :first-child {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-width: calc(30% - 0px);
+}

--- a/includes/class-cagov-design-system.php
+++ b/includes/class-cagov-design-system.php
@@ -32,5 +32,6 @@ class CAGOVDesignSystem {
         require_once CAGOV_DESIGN_SYSTEM_BLOCKS_DIR_PATH . '/blocks/card-grid/plugin.php';
         require_once CAGOV_DESIGN_SYSTEM_BLOCKS_DIR_PATH . '/blocks/content-navigation/plugin.php';
         require_once CAGOV_DESIGN_SYSTEM_BLOCKS_DIR_PATH . '/blocks/news/plugin.php';
+        require_once CAGOV_DESIGN_SYSTEM_BLOCKS_DIR_PATH . '/blocks/hero/plugin.php';
     }
 }


### PR DESCRIPTION
We are Making custom gutenberg blocks which let us define editable fields for specific HTML tag content or use a WordPress integrated image upload feature.

<img width="1032" alt="Screen Shot 2021-04-28 at 4 36 04 PM" src="https://user-images.githubusercontent.com/353360/116485372-e8f97280-a83f-11eb-9e4f-cba743c188a4.png">

The above image was created in this new gutenberg block editor by entering text for header, paragraph, button and uploading an image