### PR TITLE
Update manual CSS and JS

### DIFF
--- a/src/css/manual-caweb.v1.0.1.css
+++ b/src/css/manual-caweb.v1.0.1.css
@@ -845,3 +845,66 @@ cagov-accordion .cagov-accordion-card {
 
 /* Some manual style? Who added it? */
 .cagov-card svg { max-height: 25px; }
+
+/* Fix incorrect padding in CAWeb theme (needs to be updated in theme code) */
+@media (min-width: 1176px) {
+  .container,
+  .branding {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .first-level-link:first-child, .first-level-btn:first-child {
+    /* padding-left: 0; */
+  }
+  .top-level-nav {
+    margin-left: -15px; /* Push buttons left, to decide on */
+  }
+}
+
+/* PDF Links */
+.link-icon {
+  font-size: 0.85rem;
+  position: relative;
+  top: -3px;
+  padding-left: 2px;
+  display: inline-block;
+  text-decoration: none;
+}
+
+.pdf-link {
+  &::after {
+    font-family: "Roboto", sans-serif;
+    font-size: 0.6rem;
+    font-weight: 400;
+    content: ".PDF";
+    display: inline-block;
+    text-decoration: none;
+    outline: 1px solid;
+    outline-offset: -2px;
+    padding: 1px 4px 0px 4px;
+    position: relative;
+    left: 1px;
+    top: -3px;
+  }
+}
+
+.pdf-link-icon {
+  font-family: "Roboto", sans-serif;
+  font-size: 0.6rem;
+  font-weight: 400;
+  display: inline-block;
+  outline: 1px solid;
+  outline-offset: -2px;
+  padding: 1px 4px 0px 4px;
+  position: relative;
+  left: 1px;
+  top: -3px;
+  line-height: .9rem;
+  margin-left: 4px;
+}
+
+.no-underline-icon {
+  display: inline-block;
+  text-decoration: none;
+}

--- a/src/manual-caweb.v1.0.1.js
+++ b/src/manual-caweb.v1.0.1.js
@@ -56,3 +56,35 @@ let newScript2 = document.createElement("script");
 newScript2.src = "https://ethn.io/17561.js";
 newScript2.async = "true";
 document.querySelector('head').appendChild(newScript2);
+
+// Adding pdf span to the links with class pdf
+var pdf = '<span class="pdf-link-icon no-underline-icon" aria-hidden="true">.PDF</span><span class="sr-only"> (this is a pdf file)</span>';
+
+// selector is looking for links with pdf extension in the href
+var pdfLink = document.querySelectorAll("a[href*='.pdf']");
+for (var i=0; i < pdfLink.length; i++) {
+  pdfLink[i].innerHTML+=pdf; // += concatenates to pdf links
+}
+
+
+// Adding external link icon to the external links
+var ext = '<span class="ca-gov-icon-external-link link-icon" aria-hidden="true"></span>';
+// Check if link is external function
+function link_is_external(link_element) {
+  return (link_element.host !== window.location.host);
+}
+
+/*
+// Looping thru all link inside of the internal pages main content body
+var externalLink = document.querySelectorAll(".container .row .col-lg-10 a");
+for (var i = 0; i < externalLink.length; i++) {
+  var anchorLink = externalLink[i].href.indexOf("#") > -1;
+  var localHost = externalLink[i].href.indexOf("localhost") > -1;
+  var localUrl = externalLink[i].href.indexOf("cannabis.ca.gov") > -1;
+  var localEmail = externalLink[i].href.indexOf("@") > -1;
+  if (link_is_external(externalLink[i]) && !localUrl && !localHost && !anchorLink && !localEmail) {
+    externalLink[i].innerHTML += ext; // += concatenates to external links
+
+  }
+}*/
+


### PR DESCRIPTION
Updated the CSS and JS manual files for cannabis.
This includes the CSS & JS for the PDF links, with some visual changes updated by @adam-little.

Included the external link code as a reference, but left it commented out since it is a slightly different feature, but is also similar.

Note: This code can be a reference for adding this features to the design system. Konstantin worked on this for Covid earlier in the year & we could scope this out as a new feature.

