### PR TITLE
update file import to match new package file names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "@cagov/ds-card-grid": "^1.0.2",
         "@cagov/ds-content-navigation": "^1.0.2",
         "@cagov/ds-dropdown-menu": "^1.0.5",
-        "@cagov/ds-feature-card": "^1.0.1",
+        "@cagov/ds-feature-card": "^1.0.2",
         "@cagov/ds-feedback": "^1.0.1",
         "@cagov/ds-google-translate": "^1.0.0",
         "@cagov/ds-minus": "^1.0.0",
         "@cagov/ds-pagination": "^1.0.0",
         "@cagov/ds-plus": "^1.0.0",
-        "@cagov/ds-statewide-header": "^1.0.0",
-        "@cagov/ds-step-list": "^1.0.0"
+        "@cagov/ds-statewide-header": "^1.0.2",
+        "@cagov/ds-step-list": "^1.0.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^0.12.1",
@@ -265,9 +265,9 @@
       "integrity": "sha512-HJeUWeSHEtfqaUIeBmeNsYIT8zXLPykmDzhDYfP292jKl2JNAfBuB5vIzPX4tBJ5lAAsaWr4y4YzsHy+6n+vpQ=="
     },
     "node_modules/@cagov/ds-feature-card": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-feature-card/-/ds-feature-card-1.0.1.tgz",
-      "integrity": "sha512-170eYOhTmNatuODDoMtV/a4YU3QnXzhSAWWWx/fOr0WbsPsjCNCke23TW/zUWncMPIpT7SVegO9GyRgmTnNlnw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-feature-card/-/ds-feature-card-1.0.2.tgz",
+      "integrity": "sha512-O8+btmmEuowQ8nNopok3UFfZQpShUA/rmU4+pa9as5s9dIBwM3zhtGf1+vEw9IPdH4mAVeJB87tSDmrC+BMNYQ=="
     },
     "node_modules/@cagov/ds-feedback": {
       "version": "1.0.6",
@@ -295,14 +295,14 @@
       "integrity": "sha512-r2kpPsmgf2jPGlwRw4X1zw4ORacdc9V5iB/d/wqrxks8XkXYrK9Fo/M0Yw0MVX5ITpg1KQClgOdZunxxaoQ+qg=="
     },
     "node_modules/@cagov/ds-statewide-header": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.0.tgz",
-      "integrity": "sha512-cI8OmUUK5Uzp/Rv0Si3JuvZWiQuvptN83Mq1zccLltFAa+KLls6vxMYC6bLQm/urG7Ve+udrugSQTZMh6FZNjg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.2.tgz",
+      "integrity": "sha512-9FqX9u08RKb3lEHs1h93CoLWxMMXkibXknvemrCD3o85KcbZcVndwdq/gMDvPhLTi3XMkPqI9ihe4tRYaiqn2w=="
     },
     "node_modules/@cagov/ds-step-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-step-list/-/ds-step-list-1.0.0.tgz",
-      "integrity": "sha512-q63ajr3gO2fkVRvqf2t1tTvYPNHj9PUz6efLkvpuexyxnp1gcNd1Fa1uT1oEtcHa2rLG8TJxz/8LWtfw/IhX9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-step-list/-/ds-step-list-1.0.1.tgz",
+      "integrity": "sha512-dbi18VEssfq6XJoL9kvMmhyWumAlUzQ1a/w/qoUB75QInAZzAa+95EftoUEAWBMd0dUDwIO+yKwRE1EQGTW9Nw==",
       "dependencies": {
         "sass": "^1.37.0"
       }
@@ -7463,9 +7463,9 @@
       "integrity": "sha512-HJeUWeSHEtfqaUIeBmeNsYIT8zXLPykmDzhDYfP292jKl2JNAfBuB5vIzPX4tBJ5lAAsaWr4y4YzsHy+6n+vpQ=="
     },
     "@cagov/ds-feature-card": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-feature-card/-/ds-feature-card-1.0.1.tgz",
-      "integrity": "sha512-170eYOhTmNatuODDoMtV/a4YU3QnXzhSAWWWx/fOr0WbsPsjCNCke23TW/zUWncMPIpT7SVegO9GyRgmTnNlnw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-feature-card/-/ds-feature-card-1.0.2.tgz",
+      "integrity": "sha512-O8+btmmEuowQ8nNopok3UFfZQpShUA/rmU4+pa9as5s9dIBwM3zhtGf1+vEw9IPdH4mAVeJB87tSDmrC+BMNYQ=="
     },
     "@cagov/ds-feedback": {
       "version": "1.0.6",
@@ -7493,14 +7493,14 @@
       "integrity": "sha512-r2kpPsmgf2jPGlwRw4X1zw4ORacdc9V5iB/d/wqrxks8XkXYrK9Fo/M0Yw0MVX5ITpg1KQClgOdZunxxaoQ+qg=="
     },
     "@cagov/ds-statewide-header": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.0.tgz",
-      "integrity": "sha512-cI8OmUUK5Uzp/Rv0Si3JuvZWiQuvptN83Mq1zccLltFAa+KLls6vxMYC6bLQm/urG7Ve+udrugSQTZMh6FZNjg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.2.tgz",
+      "integrity": "sha512-9FqX9u08RKb3lEHs1h93CoLWxMMXkibXknvemrCD3o85KcbZcVndwdq/gMDvPhLTi3XMkPqI9ihe4tRYaiqn2w=="
     },
     "@cagov/ds-step-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-step-list/-/ds-step-list-1.0.0.tgz",
-      "integrity": "sha512-q63ajr3gO2fkVRvqf2t1tTvYPNHj9PUz6efLkvpuexyxnp1gcNd1Fa1uT1oEtcHa2rLG8TJxz/8LWtfw/IhX9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-step-list/-/ds-step-list-1.0.1.tgz",
+      "integrity": "sha512-dbi18VEssfq6XJoL9kvMmhyWumAlUzQ1a/w/qoUB75QInAZzAa+95EftoUEAWBMd0dUDwIO+yKwRE1EQGTW9Nw==",
       "requires": {
         "sass": "^1.37.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "@cagov/ds-card-grid": "^1.0.2",
     "@cagov/ds-content-navigation": "^1.0.2",
     "@cagov/ds-dropdown-menu": "^1.0.5",
-    "@cagov/ds-feature-card": "^1.0.1",
+    "@cagov/ds-feature-card": "^1.0.2",
     "@cagov/ds-feedback": "^1.0.1",
     "@cagov/ds-google-translate": "^1.0.0",
     "@cagov/ds-minus": "^1.0.0",
     "@cagov/ds-pagination": "^1.0.0",
     "@cagov/ds-plus": "^1.0.0",
-    "@cagov/ds-statewide-header": "^1.0.0",
-    "@cagov/ds-step-list": "^1.0.0"
+    "@cagov/ds-statewide-header": "^1.0.2",
+    "@cagov/ds-step-list": "^1.0.1"
   }
 }

--- a/src/css/sass/index.scss
+++ b/src/css/sass/index.scss
@@ -10,16 +10,16 @@
 @import '../../components/site-footer/_style';
 @import '../../components/footer/_style';
 
-@import '../../../node_modules/@cagov/ds-statewide-header/src/style.scss'; // statewide header
 @import '../../../node_modules/@cagov/ds-base-css/src/_core.scss'; // unthemed base css
-@import '../../../node_modules/@cagov/ds-step-list/index.scss'; // step list
-@import '../../../node_modules/@cagov/ds-feature-card/css/index'; // now imported from npm module
+
+@import '../../../node_modules/@cagov/ds-statewide-header/src/index.scss'; // statewide header
+@import '../../../node_modules/@cagov/ds-step-list/src/index.scss'; // step list
+@import '../../../node_modules/@cagov/ds-feature-card/index'; // now imported from npm module
+
 @import '../../../node_modules/@cagov/ds-card-grid/index'; // now imported from npm module
-// @import '../../../node_modules/@cagov/ds-branding/_style'; // now imported from npm module
 @import '../../../node_modules/@cagov/ds-branding/src/index.scss'; // now imported from npm module
 @import '../../../node_modules/@cagov/ds-content-navigation/src/index.scss'; // now imported from npm module
 @import '../../../node_modules/@cagov/ds-dropdown-menu/src/index.scss'; // now imported from npm module
-/* these component should all be published and installed so they aren't duplicated here and in design-system */
 
 
 


### PR DESCRIPTION
New versions of some CSS only modules were published that conform to file naming patterns for css files. The latest version of these packages were installed and the imports updated