### PR TITLE
Rename ofiicial-logo to official-logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@cagov/ds-plus": "^1.0.0",
     "@cagov/ds-skip-to-content": "^1.0.0",
     "@cagov/ds-statewide-footer": "^1.0.0",
-    "@cagov/ds-statewide-header": "^1.0.5",
+    "@cagov/ds-statewide-header": "^1.0.6",
     "@cagov/ds-step-list": "^1.0.1"
   }
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -713,11 +713,11 @@ cagov-announcement-list .post-list-item {
     max-width: 1140px;
     margin: 0 auto;
     padding: 0 10px 0 10px; }
-  .official-header .ofiicial-logo {
+  .official-header .official-logo {
     display: flex;
     flex-wrap: wrap;
     align-items: center; }
-    .official-header .ofiicial-logo .cagov-logo {
+    .official-header .official-logo .cagov-logo {
       margin: 0 10px; }
   .official-header svg {
     padding: 0; }

--- a/src/templates/_includes/statewide-header.njk
+++ b/src/templates/_includes/statewide-header.njk
@@ -1,6 +1,6 @@
 <div class="official-header">
   <div class="container">
-    <div class="ofiicial-logo">
+    <div class="official-logo">
       <a class="cagov-logo" href="https://ca.gov" title="ca.gov" target="_blank" rel="noopener">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
                     y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"


### PR DESCRIPTION
This small change to ds-statewide-header markup corresponds to a design-system change at cagov/design-system#120. We should wait for upstream changes in the design-system before merging this change here in cannabis.ca.gov.