### PR TITLE
Slow down workflows

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -1,7 +1,8 @@
 name: End-to-end tests cypress
 on:
-  schedule:
-    - cron: "*/5 * * * *"
+  push:
+    branches:
+      - main
 
 jobs:
   cypress-run:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,8 @@
 name: End to end tests playwright
 on:
-  schedule:
-    - cron: "*/5 * * * *"
+  push:
+    branches:
+      - main
     
 jobs:
   build_deploy:

--- a/.github/workflows/redirects.yml
+++ b/.github/workflows/redirects.yml
@@ -2,7 +2,7 @@ name: Eleventy Build Main
 on:
   push:
     branches:
-      - redirect-config
+      - main
 jobs:
   build_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stop the end to end testing workflows from running on a schedule, they have been running smoothly, satisfied these tools are not flaky with this test suite