### PR TITLE
updated content-navigation to v1.0.4 and statewide-header to v1.0.8 #234

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@cagov/ds-base-css": "^1.0.4",
         "@cagov/ds-branding": "^1.0.4",
         "@cagov/ds-card-grid": "^1.0.2",
-        "@cagov/ds-content-navigation": "^1.0.3",
+        "@cagov/ds-content-navigation": "^1.0.4",
         "@cagov/ds-dropdown-menu": "^1.0.11",
         "@cagov/ds-feature-card": "^1.0.2",
         "@cagov/ds-feedback": "^1.0.1",
@@ -25,7 +25,7 @@
         "@cagov/ds-plus": "^1.0.0",
         "@cagov/ds-skip-to-content": "^1.0.0",
         "@cagov/ds-statewide-footer": "^1.0.1",
-        "@cagov/ds-statewide-header": "^1.0.7",
+        "@cagov/ds-statewide-header": "^1.0.8",
         "@cagov/ds-step-list": "^1.0.1"
       },
       "devDependencies": {
@@ -1023,9 +1023,9 @@
       "integrity": "sha512-4mAs2zZ6VdCXUfC04G6JXId5oWJB8M8dpQdWMXogZ5rMyp5bAoJKJW0pR7uIVPbTyH/aNW+UiFQqdsizKqrOfA=="
     },
     "node_modules/@cagov/ds-content-navigation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-content-navigation/-/ds-content-navigation-1.0.3.tgz",
-      "integrity": "sha512-9jsqJ7ECtBxdQjKWODeuHHoVokm/yr+jDocB8FcIBNThMLla+rqIVWcvf7/HgOkh2GP3gt/cxFXs49xZwx9b2Q=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-content-navigation/-/ds-content-navigation-1.0.4.tgz",
+      "integrity": "sha512-Vabu0tKIY1CZa5SsnOfZ5qwFUo2veccxWY5y2ecBmSznazlekpbS4K43opZGrw3aXbioQAvLY9HQ1Wupn6h2dQ=="
     },
     "node_modules/@cagov/ds-dropdown-menu": {
       "version": "1.0.11",
@@ -1083,10 +1083,9 @@
       "license": "ISC"
     },
     "node_modules/@cagov/ds-statewide-header": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.7.tgz",
-      "integrity": "sha512-0DGVXKoYHFK5gX9iiBzD5yaGQWe/2Ej923v5x4Lqw1Anq2OuyKiLUKN2W1GqYgYTFdauo+ofAIdHYjW4dxA5Pw==",
-      "license": "ISC"
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.8.tgz",
+      "integrity": "sha512-6Cr3b9mY06ocPK9duc3HOxixOchLMeQtEbmJB7etuv+eFc8s6WNpmjl4WtTclKvRI0G6inmziqIQQwHQCkTChA=="
     },
     "node_modules/@cagov/ds-step-list": {
       "version": "1.0.1",
@@ -1694,6 +1693,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -12670,9 +12670,9 @@
       "integrity": "sha512-4mAs2zZ6VdCXUfC04G6JXId5oWJB8M8dpQdWMXogZ5rMyp5bAoJKJW0pR7uIVPbTyH/aNW+UiFQqdsizKqrOfA=="
     },
     "@cagov/ds-content-navigation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-content-navigation/-/ds-content-navigation-1.0.3.tgz",
-      "integrity": "sha512-9jsqJ7ECtBxdQjKWODeuHHoVokm/yr+jDocB8FcIBNThMLla+rqIVWcvf7/HgOkh2GP3gt/cxFXs49xZwx9b2Q=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-content-navigation/-/ds-content-navigation-1.0.4.tgz",
+      "integrity": "sha512-Vabu0tKIY1CZa5SsnOfZ5qwFUo2veccxWY5y2ecBmSznazlekpbS4K43opZGrw3aXbioQAvLY9HQ1Wupn6h2dQ=="
     },
     "@cagov/ds-dropdown-menu": {
       "version": "1.0.11",
@@ -12728,9 +12728,9 @@
       "integrity": "sha512-45vYnb6abWRTVX1qY0Yg6Cx+xf4EEbqWil22iNW5ornonQ+jg2tuwvPmtV5/tKdU0R2LUzaY7fYraouVkKiJRw=="
     },
     "@cagov/ds-statewide-header": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.7.tgz",
-      "integrity": "sha512-0DGVXKoYHFK5gX9iiBzD5yaGQWe/2Ej923v5x4Lqw1Anq2OuyKiLUKN2W1GqYgYTFdauo+ofAIdHYjW4dxA5Pw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-header/-/ds-statewide-header-1.0.8.tgz",
+      "integrity": "sha512-6Cr3b9mY06ocPK9duc3HOxixOchLMeQtEbmJB7etuv+eFc8s6WNpmjl4WtTclKvRI0G6inmziqIQQwHQCkTChA=="
     },
     "@cagov/ds-step-list": {
       "version": "1.0.1",
@@ -13261,6 +13261,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@cagov/ds-base-css": "^1.0.4",
     "@cagov/ds-branding": "^1.0.4",
     "@cagov/ds-card-grid": "^1.0.2",
-    "@cagov/ds-content-navigation": "^1.0.3",
+    "@cagov/ds-content-navigation": "^1.0.4",
     "@cagov/ds-dropdown-menu": "^1.0.11",
     "@cagov/ds-feature-card": "^1.0.2",
     "@cagov/ds-feedback": "^1.0.1",
@@ -68,7 +68,7 @@
     "@cagov/ds-plus": "^1.0.0",
     "@cagov/ds-skip-to-content": "^1.0.0",
     "@cagov/ds-statewide-footer": "^1.0.1",
-    "@cagov/ds-statewide-header": "^1.0.7",
+    "@cagov/ds-statewide-header": "^1.0.8",
     "@cagov/ds-step-list": "^1.0.1"
   }
 }

--- a/src/js/index-headless.js
+++ b/src/js/index-headless.js
@@ -8,6 +8,7 @@ import '@cagov/ds-dropdown-menu';
 import '@cagov/ds-content-navigation';
 import '@cagov/ds-pdf-icon/src/index.js';
 import '@cagov/ds-back-to-top/src/index.js';
+import '@cagov/ds-statewide-header/src/index.js';
 
 import '../components/post-list-headless/index.js';
 import '../components/page-alert/index.js';


### PR DESCRIPTION
This update will hide statewide-header on scroll up and will make content navigation sticky.
![Screen Shot 2021-09-28 at 12 46 35 PM](https://user-images.githubusercontent.com/31669748/135155702-7fcd3175-58e8-4cd5-9e52-00f1afe78f9e.png)
![Screen Shot 2021-09-28 at 12 47 00 PM](https://user-images.githubusercontent.com/31669748/135155717-ebdab55b-cae8-402b-9e4b-1ff69e76fc4a.png)
