### PR TITLE
Revert "adding "api." to the cannabis wordpress source URL"

### DIFF
--- a/wordpress/wordpress-to-github.config.json
+++ b/wordpress/wordpress-to-github.config.json
@@ -5,7 +5,7 @@
     "description": "wordpress-to-github endpoints config file"
   },
   "data": {
-    "wordpress_source_url": "https://api.cannabis.ca.gov",
+    "wordpress_source_url": "https://cannabis.ca.gov",
     "github_targets": [
       {
         "outputBranch": "main",


### PR DESCRIPTION
Reverts cagov/cannabis.ca.gov#388

This is causing url match errors.