### PR TITLE
add scroll tracking to all pages

### DIFF
--- a/src/js/headless/index.js
+++ b/src/js/headless/index.js
@@ -1,5 +1,3 @@
-import boxTracker from "./box-tracker.js";
-
 export default function setupAnalytics() {
 
   document.querySelectorAll('cagov-accordion').forEach((acc) => {
@@ -93,6 +91,7 @@ export default function setupAnalytics() {
       }
     });
   };
+  window.addEventListener('scroll', throttle(scrollHandler('homepage'), 1000));
 
   // Give all analytics calls a chance to finish before following the link.
   // Note this generates a function for use by an event listener.


### PR DESCRIPTION
On covid we run this on the homepage and equity dash. 

Do we want this event firing on all pages on cannabis @traintestbritt? It is throttled so won't have any visitor impact.

box tracker import removed because that is only used on covid for tracking when specific charts come into view on the equity dash