### PR TITLE
#387 Table styles.

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,6 +1,6 @@
 .wp-block-table {
   table {
-    border: 1px solid var(--black, #000000);
+    border: 1px solid var(--gray-700, #a09fa7);
     border-collapse: collapse;
     margin: 0 0 15px;
     text-align: left;
@@ -32,7 +32,7 @@
   }
   td,
   th {
-    border: 1px solid var(--black, #000000);
-    padding: 6px 24px;
+    border: 1px solid var(--gray-700, #a09fa7);
+    padding: 16px;
   }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -35,8 +35,4 @@
     border: 1px solid var(--black, #000000);
     padding: 6px 24px;
   }
-
-  ul {
-    margin-bottom: 0 !important; // !important is needed to override aggressive styles coming from body.interior-page
-  }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,0 +1,42 @@
+.wp-block-table {
+  table {
+    border: 1px solid var(--black, #000000);
+    border-collapse: collapse;
+    margin: 0 0 15px;
+    text-align: left;
+
+    & + figcaption {
+      margin-bottom: 15px;
+    }
+  }
+
+  &.aligncenter table {
+    margin: 0 auto 15px;
+
+    & + figcaption {
+      margin: 0 auto 15px;
+      text-align: center;
+    }
+  }
+
+  &.alignright table {
+    margin: 0 0 15px auto;
+
+    & + figcaption {
+      text-align: right;
+    }
+  }
+
+  th {
+    font-weight: bold;
+  }
+  td,
+  th {
+    border: 1px solid var(--black, #000000);
+    padding: 6px 24px;
+  }
+
+  ul {
+    margin-bottom: 0 !important; // !important is needed to override aggressive styles coming from body.interior-page
+  }
+}

--- a/src/css/sass/index.scss
+++ b/src/css/sass/index.scss
@@ -6,6 +6,8 @@
 @import "../../components/page-alert/index"; /* copied from gutenberg custom block */
 @import "../../components/post-list-headless/_style";
 @import "../../components/regulatory-outline/_regulatory-outline";
+@import "../../components/table/_table";
+
 
 /* NAVIGATION ELEMENTS */
 @import "../../components/site-footer/index.scss";


### PR DESCRIPTION
- `.wp-block-table table, .wp-block-table table td, .wp-block-table table th {border: 1px solid var(--gray-200,#ededef)!important;` overrides the border color  but I believe it can be delted through the Wordpress uI at CAWeb Options > Custom CSS > Manual CSS
- Related PR: https://github.com/cagov/design-system/pull/144