### PR TITLE
replace favicon, refactor media regex

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -76,8 +76,7 @@ module.exports = function(eleventyConfig) {
         }
       }
       // modify the wordpress asset links here opportunistically because we are already looping through tempaltes with njk transformed into HTML 
-      item.template.frontMatter.content = item.template.frontMatter.content.replace(new RegExp('http://cannabis.ca.gov/','g'),'/');
-      item.template.frontMatter.content = item.template.frontMatter.content.replace(new RegExp('https://cannabis.ca.gov/','g'),'/');
+      item.template.frontMatter.content = item.template.frontMatter.content.replace(/https?:\/\/cannabis\.ca\.gov\//g,'/');
     });
     pressPosts.sort((a,b) => {
       return new Date(b.data.data.date).getTime() - new Date(a.data.data.date).getTime();

--- a/pages/_includes/layouts/index.njk
+++ b/pages/_includes/layouts/index.njk
@@ -35,8 +35,8 @@
   <meta name="twitter:image:width" content="{{ social.image.width | safe }}" />
   <meta name="twitter:image:height" content="{{ social.image.height | safe }}" />
 
-  <link title="Fav Icon" rel="icon" href="/media/sites/2/2021/07/cannabis_favicon_16x16.png">
-  <link rel="shortcut icon" href="/media/sites/2/2021/07/cannabis_favicon_16x16.png">
+  <link title="Fav Icon" rel="icon" href="/wp-content/uploads/sites/2/2021/07/cannabis_favicon_16x16.png">
+  <link rel="shortcut icon" href="/wp-content/uploads/sites/2/2021/07/cannabis_favicon_16x16.png">
 
   <!-- Google Analytics performance -->
   <link rel="preconnect" href="https://www.google-analytics.com/">


### PR DESCRIPTION
Favicon got lost when we did the media url update, this fixes the favicon reference
Checked for other similar issues, found none

Also refactored regex with Carter's suggestion