### PR TITLE
Containers' right and left padding fixes #413

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@cagov/ds-plus": "^1.0.0",
         "@cagov/ds-regulatory-outline": "^1.0.0",
         "@cagov/ds-skip-to-content": "^1.0.0",
-        "@cagov/ds-statewide-footer": "^1.0.3",
+        "@cagov/ds-statewide-footer": "^1.0.4",
         "@cagov/ds-statewide-header": "^1.0.10",
         "@cagov/ds-step-list": "^1.0.1",
         "@cagov/ds-table": "^1.0.0"
@@ -1087,9 +1087,9 @@
       "integrity": "sha512-Mj0ltoRjpZ9NnRSNBf40sNhUeX755Q/J2UdkLl/VL5WklofVL/ovaafFdPJSmetr8eE86enRqruRB0MAeOk4VQ=="
     },
     "node_modules/@cagov/ds-statewide-footer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-footer/-/ds-statewide-footer-1.0.3.tgz",
-      "integrity": "sha512-2XxXn2sGxSVx7rrBlf5+/DFGhr8q0C3qTSDZbIRcE5ZyMSqP8yBYwDeq5lgqjKAduiuQ8C1TgZjtafUpsyJP4Q=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-footer/-/ds-statewide-footer-1.0.4.tgz",
+      "integrity": "sha512-/oPcbXNr6N2Txtow7DpRPqnJ5KL5DYgUMACbvclYFGtzDZ05pwF+tomOvNcVvvBzKQ3GQp12CjUXwlq092DNoA=="
     },
     "node_modules/@cagov/ds-statewide-header": {
       "version": "1.0.10",
@@ -12589,9 +12589,9 @@
       "integrity": "sha512-Mj0ltoRjpZ9NnRSNBf40sNhUeX755Q/J2UdkLl/VL5WklofVL/ovaafFdPJSmetr8eE86enRqruRB0MAeOk4VQ=="
     },
     "@cagov/ds-statewide-footer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-footer/-/ds-statewide-footer-1.0.3.tgz",
-      "integrity": "sha512-2XxXn2sGxSVx7rrBlf5+/DFGhr8q0C3qTSDZbIRcE5ZyMSqP8yBYwDeq5lgqjKAduiuQ8C1TgZjtafUpsyJP4Q=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-statewide-footer/-/ds-statewide-footer-1.0.4.tgz",
+      "integrity": "sha512-/oPcbXNr6N2Txtow7DpRPqnJ5KL5DYgUMACbvclYFGtzDZ05pwF+tomOvNcVvvBzKQ3GQp12CjUXwlq092DNoA=="
     },
     "@cagov/ds-statewide-header": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@cagov/ds-plus": "^1.0.0",
     "@cagov/ds-regulatory-outline": "^1.0.0",
     "@cagov/ds-skip-to-content": "^1.0.0",
-    "@cagov/ds-statewide-footer": "^1.0.3",
+    "@cagov/ds-statewide-footer": "^1.0.4",
     "@cagov/ds-statewide-header": "^1.0.10",
     "@cagov/ds-step-list": "^1.0.1",
     "@cagov/ds-table": "^1.0.0"

--- a/src/css/sass/colorschemes/cannabis.scss
+++ b/src/css/sass/colorschemes/cannabis.scss
@@ -1,30 +1,30 @@
 /* Cannabis logo font */
 @font-face {
-	font-family: 'Lexend';
-	src: url('/fonts/Lexend-Medium.woff2') format('woff2');
-  }
+  font-family: "Lexend";
+  src: url("/fonts/Lexend-Medium.woff2") format("woff2");
+}
 
 /* Colorscheme root variables */
 :root {
   /* Theme colors */
-  --primary-color: #064E66;
+  --primary-color: #064e66;
   --primary-dark-color: #043747;
   --primary-light-color: #518394;
-  --primary-lightest-color: #B4CAD1;
+  --primary-lightest-color: #b4cad1;
   --primary-hover-color: #043747;
 
-  --secondary-color: #2F4C2C;
-  --secondary-dark-color: #21351F;
-  --secondary-light-color: #6D826B;
-  --secondary-lightest-color: #C1C9C0;
-  --secondary-hover-color: #21351F;
+  --secondary-color: #2f4c2c;
+  --secondary-dark-color: #21351f;
+  --secondary-light-color: #6d826b;
+  --secondary-lightest-color: #c1c9c0;
+  --secondary-hover-color: #21351f;
 
-  --highlight-color: #C0633B;
+  --highlight-color: #c0633b;
   --highlight-dark-color: #864529;
-  --highlight-light-color: #D39276;
-  --highlight-lightest-color: #ECD0C4;
+  --highlight-light-color: #d39276;
+  --highlight-lightest-color: #ecd0c4;
   --secondary-hover-color: #864529;
-  
+
   --org-name-state-font: "Arial", "Helvetica", sans-serif;
   --org-name-state-font-size: 0.875rem;
   --org-name-state-text-transform: uppercase;
@@ -34,3 +34,10 @@
   --org-name-dept-font-weight: 500;
 }
 
+// !Note: Monolith WP statewide footer menu override:
+// ca.gov menu item is nessesary in monolith, but is not needed in headless.
+// Please address it when healess goes live by removing ca.gov menu item from WP footer menu
+// then remove styles below:
+footer .footer-secondary-links a:first-child {
+  display: none;
+}


### PR DESCRIPTION
Agency footer: Updated agency footer's container left and right padding to 16px (instead of 1rem) to be consistent with other components.

Statewide-footer: Updated statewide footer container's padding to 16px instead of 1rem to make it consistent with other components.
![footer](https://user-images.githubusercontent.com/31669748/137367100-35f8e7b4-4ce0-4775-85fa-02ceba38988f.jpg)


Base-css: Updated content-footer container right and left padding to 16px to make it consistent with other components. Also, removed right and left margin from the page container, instead added left and right padding to it.

Branding: Fixed focus color variables to --highlight-color. Fixed focus aesthetics for toggle menu button in mobile. Updated gap distance between search and toggle menu mobile buttons to 24px according to figma. Updated branding container's left and right padding to 16px to be consistent with other components.
![branding](https://user-images.githubusercontent.com/31669748/137366375-6b1e02ff-398c-45e0-ae5a-f0e48df5988e.jpg)

Feedback: Removed line height from the feedback's main h2 label in mobile and added 1rem margin bottom to it.
![feedback](https://user-images.githubusercontent.com/31669748/137366515-f979c83f-0a4a-412a-a188-e670abfbb3aa.jpg)


MENU: Removed jump effect when opening dropdown menu in mobile by adding top and bottom padding to the :first and :last child. Polished focus outline aesthetics for all menu links. Added left and right 16px padding to the entire menu container to make it consistent with all other components.
![menu](https://user-images.githubusercontent.com/31669748/137366567-8ac90665-feca-4e4b-9fbc-48c906a15c23.jpg)

Statewide-header: Updated statewide header container's left and right padding to 16px.
![header](https://user-images.githubusercontent.com/31669748/137367869-fd963b91-7f69-4c20-b1bd-7f354e9a4e96.jpg)

