### PR TITLE
fix template assignments to match what is provided by latest wordpress

### DIFF
--- a/pages/_includes/layouts/index.njk
+++ b/pages/_includes/layouts/index.njk
@@ -74,10 +74,10 @@
     {%- elif templatestring == 'template-page-single-column' -%}
       {% include "../layouts/templates/single-column.njk" %}
       {# Normal page template, with content nav and breadcrumb, if default the API will return "page" #}
-    {% elif templatestring == 'page' -%}
+    {% elif templatestring == 'template-page' -%}
       {% include "../layouts/templates/page.njk" %}
       {# Normal post template, with category if default the API will return "post" #}
-    {% elif templatestring == 'post' -%}
+    {% elif templatestring == 'template-single' -%}
       {% include "../layouts/templates/post.njk" %}
     {% elif templatestring == 'template-single-press-release ' -%}
       {# We are developing more templates for special post types, like press releases and events. #}


### PR DESCRIPTION
Headless template assignments were no longer working as desired: internal pages were getting the landing template assigned so they are missing the content navigation now on headless.cannabis.ca.go

This changes the template assignment logic to match values now returned from wordpress