### PR TITLE
disable redirect retrieval

### DIFF
--- a/wordpress/config/wordpress-to-github.config.json
+++ b/wordpress/config/wordpress-to-github.config.json
@@ -10,12 +10,6 @@
     "PagePath": "pages/wordpress/pages",
     "MediaPath": "wordpress/media",
     "ExcludeProperties": ["content", "_links"],
-    "ApiRequests": [
-      {
-        "Destination": "wordpress/config/redirects.json",
-        "Source": "/wp-json/redirection/v1/export-public/1/json",
-        "ExcludeProperties": []
-      }
-    ]
+    "ApiRequests": []
   }
 }


### PR DESCRIPTION
The redirect endpoint is changing its updated date hourly

I cannot tell this service to retrieve the data via proxy because it uses the WordPress host as the url base

Retrieving a new redirects file every hour causes
- Write to github
- Message to slack
- New build to AWs
- CloudFront cache clear

The CloudFront cache clear looks like it will end up costing $1/day if it continues like this so I am disabling until we can remove the date from the redirects file