### PR TITLE
Add CloudFront invalidation to staging

### DIFF
--- a/.github/workflows/eleventy_build_staging_pantheon.yml
+++ b/.github/workflows/eleventy_build_staging_pantheon.yml
@@ -43,3 +43,24 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
           SOURCE_DIR: ./docs # only move built directory
+
+      # Reset the cache-control headers on static assets on S3 bucket
+      - name: Reset cache-control on static files
+        uses: prewk/s3-cp-action@v2
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: 'us-west-1'   # optional: defaults to us-east-1
+          source: './docs/fonts'
+          dest: 's3://staging.cannabis.ca.gov/fonts'
+          flags: --recursive --cache-control max-age=15552000
+
+      # Invalidate Cloudfront production distribution
+      - name: invalidate
+        uses: chetan/invalidate-cloudfront-action@v1.3
+        env:
+          DISTRIBUTION: 'E1FCC4093TP0Q2'
+          PATHS: '/*'
+          AWS_REGION: 'us-west-1'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}    


### PR DESCRIPTION
Adds CloudFront cache invalidation to the GitHub Action for staging.cannabis.ca.gov builds.