### PR TITLE
Fix announcements page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,7 @@ const {
 const {
   renderPostLists,
   renderWordpressPostTitleDate,
+  setDefaultAttributes,
 } = require("./src/js/eleventy/post-list/render.js");
 const { renderEventLists } = require("./src/js/eleventy/event-list/render.js");
 const {
@@ -86,11 +87,8 @@ module.exports = function eleventyBuild(eleventyConfig) {
   eleventyConfig.addFilter("relativePath", relativePath);
 
   // Used in announcements.njk
-  eleventyConfig.addFilter("displayPostInfo", (item) =>
-    renderWordpressPostTitleDate(item.data, {
-      showExcerpt: true,
-      showPublishDate: true,
-    })
+  eleventyConfig.addFilter("displayPostInfo", (item) => 
+    renderWordpressPostTitleDate(item.data, setDefaultAttributes())
   );
 
   eleventyConfig.addTransform("htmlTransforms", (html, outputPath) => {

--- a/pages/announcements.njk
+++ b/pages/announcements.njk
@@ -6,7 +6,7 @@ pagination:
 permalink: "about-us/announcements/{{pagination.pageNumber}}/"
 ---
 
-<div class="post-list-items">
+<div class="post-list-items expanded-listings">
 {%- for item in pagination.items %}
   {{ item | displayPostInfo | safe }}
 {% endfor -%}

--- a/src/components/post-list/_paginated.scss
+++ b/src/components/post-list/_paginated.scss
@@ -1,0 +1,20 @@
+.post-list-items.expanded-listings {
+  .post-list-item {
+    margin-bottom: 32px;
+
+    .link-title {
+      line-height: 1.75;
+      margin-bottom: 12px;
+
+      a {
+        font-size: 28px;
+        font-weight: 700;
+        text-decoration: none;
+      }
+    }
+
+    .date {
+      font-size: 18px;
+    }
+  }
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -8,5 +8,6 @@
 @import "wordpress"; /* Restyle content markup coming from WordPress API */
 @import "post-lists"; /* Announcements, Events and other styles */
 @import "svg-icons"; 
+@import "../components/post-list/paginated";
 
 /* STYLE FIXES AND PATCHES */

--- a/src/js/eleventy/post-list/render.js
+++ b/src/js/eleventy/post-list/render.js
@@ -118,6 +118,19 @@ const renderWordpressPostTitleDate = (
     `;
   }
 
+  if (attributes.showPagination && attributes.showPagination !== "false") {
+    return `
+      <div class="post-list-item">
+        ${categoryType}
+        <div class="link-title">
+          ${formattedTitle}
+        </div>
+        ${getExcerpt}
+        ${getDate}
+      </div>
+    `;
+  }
+
   return `
     <div class="post-list-item">
       ${categoryType}
@@ -136,7 +149,7 @@ const renderWordpressPostTitleDate = (
  *                            from the cagov-post-list component elements's 'data-' attributes, or dataset.
  * @returns {Object} The same attributes object, now hydrated with defaults for any missing values.
  */
-const setDefaultAttributes = (attributes) => {
+const setDefaultAttributes = (attributes = {}) => {
   const defaults = {
     order: "desc",
     count: "10",
@@ -163,6 +176,10 @@ const setDefaultAttributes = (attributes) => {
  * @returns {string} A string of rendered HTML.
  */
 const applyPostsTemplate = (posts, totalPosts, attributes) => {
+  const itemsClass = 
+    (attributes.showPagination && attributes.showPagination !== "false") 
+    ? "post-list-items expanded-listings" 
+    : "post-list-items";
   let innerContent;
   let renderedPosts;
   if (posts !== undefined && posts !== null && posts.length > 0) {
@@ -171,7 +188,7 @@ const applyPostsTemplate = (posts, totalPosts, attributes) => {
         renderWordpressPostTitleDate(post.data, attributes)
       );
       innerContent = `
-        <div class="post-list-items">
+        <div class="${itemsClass}">
           ${renderedPosts.join("")}
         </div>
         ${attributes.readMore}
@@ -252,4 +269,8 @@ const renderPostLists = function (html) {
   return result;
 };
 
-module.exports = { renderPostLists, renderWordpressPostTitleDate };
+module.exports = { 
+  renderPostLists, 
+  renderWordpressPostTitleDate, 
+  setDefaultAttributes 
+};


### PR DESCRIPTION
Fixes the announcements page.

* Minimum style changes to help the page look more like the live Flywheel version.
* Fixes to post-list rendering to help out with paginated content.

Tried to do this with the least edits possible.