### PR TITLE
Main domain fixes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -132,6 +132,14 @@ module.exports = function eleventyBuild(eleventyConfig) {
         return false;
       });
 
+      // Temp patch for weird issue with absolute url permalinks for og meta
+      if (html !== undefined && html.includes("//wp-content/uploads/")) {
+        html = html.replace(
+          new RegExp("//wp-content/uploads/", "g"),
+          `/${config.build.docs_media}/`
+        );
+      }
+      
       // Minify HTML
       html = htmlmin.minify(html, {
         useShortDoctype: true,

--- a/.github/workflows/eleventy_build_headless.yml
+++ b/.github/workflows/eleventy_build_headless.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir dist
           npm install
-          SITE_ENV=production DOMAIN=cannabis.ca.gov npm run build
+          SITE_ENV=production DOMAIN=headless.cannabis.ca.gov npm run build
           # npm run test:setup
       - name: Write robots.txt
         run: |
@@ -41,7 +41,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          publish_branch: deploy_production
+          publish_branch: deploy_headless
       
       # Set up AWS CLI
       - name: Configure AWS Credentials
@@ -51,11 +51,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
-      # Deploy to cannabis.ca.gov
-      - name: Deploy to S3 (cannabis.ca.gov)
-        run: aws s3 sync --follow-symlinks --delete ./docs s3://cannabis.ca.gov
-      - name: Invalidate Cloudfront (cannabis.ca.gov)
-        run: aws cloudfront create-invalidation --distribution-id E2RLC9PDB1JLNI --paths "/*"
+      # Deploy to headless.cannabis.ca.gov
+      - name: Deploy to S3 (headless.cannabis.ca.gov)
+        run: aws s3 sync --follow-symlinks --delete ./docs s3://headless.cannabis.ca.gov
+      - name: Invalidate Cloudfront (headless.cannabis.ca.gov)
+        run: aws cloudfront create-invalidation --distribution-id E1HY53GZXHPHRV --paths "/*"
 
       - name: Deploy redirects
         run: |

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir dist
           npm ci --legacy-peer-deps  
-          DOMAIN=${URLSAFE_BRANCH_NAME}.pr.cannabis.ca.gov npm run build
+          SITE_ENV=production DOMAIN=${URLSAFE_BRANCH_NAME}.pr.cannabis.ca.gov npm run build
       - name: Write robots.txt
         run: |
           echo 'User-agent: *' > docs/robots.txt

--- a/.github/workflows/eleventy_build_staging.yml
+++ b/.github/workflows/eleventy_build_staging.yml
@@ -16,7 +16,7 @@ jobs:
   build_deploy:
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel previous build
+      - name: Cancel previous site:build:staging
         uses: n1hility/cancel-previous-runs@v2
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir dist
           npm install
-          npm run site:build:staging
+          SITE_ENV=staging DOMAIN=staging.cannabis.ca.gov npm run build
           # npm run test:setup
       - name: Write robots.txt
         run: |

--- a/config/config.json
+++ b/config/config.json
@@ -39,7 +39,6 @@
         "eleventy_menu": "pages/_content/menu",
         "eleventy_redirects": "pages/_content/redirects",
         "docs_media": "wp-content/uploads/sites/2",
-        "host_name": "headless.cannabis.ca.gov",
         "upload_folder": "wp-content/uploads/",
         "upload_folder_flywheel": "wp-content/uploads/sites/2/",
         "replace_urls": [
@@ -73,6 +72,7 @@
             "http://wordpress.test:8888/wp-content/uploads/"
         ],
         "editor_url": "https://api.cannabis.ca.gov",
-        "canonical_site_url": "https://headless.cannabis.ca.gov"
+        "canonical_site_url": "https://cannabis.ca.gov",
+        "host_name": "headless.cannabis.ca.gov"
     }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -29,14 +29,24 @@ const getConfig = () => {
     staticContentPaths
   );
 
+  const defaultDomain = config.build.host_name;
+  const DOMAIN = process.env.DOMAIN || defaultDomain;
+  config.build.host_name = DOMAIN; //"cannabis.ca.gov";
+
+  if (process.env.SITE_ENV === "production") {
+    config.build.canonical_site_url = "https://cannabis.ca.gov";
+  }
+
+  if (process.env.SITE_ENV === "headless") {
+    config.build.canonical_site_url = "https://headless.cannabis.ca.gov";
+  }
+
   if (process.env.SITE_ENV === "staging") {
     config.build.canonical_site_url = "https://staging.cannabis.ca.gov";
-    config.build.host_name = "https://staging.cannabis.ca.gov";
   }
 
   if (process.env.SITE_ENV === "localhost") {
     config.build.canonical_site_url = "http://localhost:8080";
-    config.build.host_name = "http://localhost:8080";
   }
 
   return config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7462,8 +7462,8 @@
       }
     },
     "node_modules/static-content-cannabis": {
-      "version": "2.0.196",
-      "resolved": "git+ssh://git@github.com/cagov/static-content-cannabis.git#8f0e309f94c5687364d7cf74b2d5d408f99d3da3"
+      "version": "2.0.191",
+      "resolved": "git+ssh://git@github.com/cagov/static-content-cannabis.git#23570a8eb358a43c653de1cd42eed405f97b4926"
     },
     "node_modules/static-content-cannabis-debugging": {
       "name": "static-content-cannabis",
@@ -13648,7 +13648,7 @@
       }
     },
     "static-content-cannabis": {
-      "version": "git+ssh://git@github.com/cagov/static-content-cannabis.git#8f0e309f94c5687364d7cf74b2d5d408f99d3da3",
+      "version": "git+ssh://git@github.com/cagov/static-content-cannabis.git#23570a8eb358a43c653de1cd42eed405f97b4926",
       "from": "static-content-cannabis@github:cagov/static-content-cannabis#main"
     },
     "static-content-cannabis-debugging": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "build": "eleventy",
     "dev": "npm run site:watch:dev",
-    "site:build:dev": "npm run content:update && cross-env NODE_ENV=development SITE_ENV=localhost eleventy",
-    "site:build:staging": "npm run content:update:staging && cross-env SITE_ENV=staging eleventy",
+    "site:build:dev": "cross-env NODE_ENV=development SITE_ENV=localhost DOMAIN=localhost eleventy",
+    "site:build:staging": "cross-env SITE_ENV=staging DOMAIN=staging.cannabis.ca.gov eleventy",
+    "site:build:headless": "cross-env NODE_ENV=production SITE_ENV=headless DOMAIN=headless.cannabis.ca.gov eleventy",
+    "site:build:production": "cross-env NODE_ENV=production SITE_ENV=production DOMAIN=cannabis.ca.gov eleventy",
     "site:watch:dev": "cross-env NODE_ENV=development SITE_ENV=localhost eleventy --watch --serve --incremental",
     "site:watch:staging": "cross-env NODE_ENV=development SITE_ENV=staging eleventy --watch --serve --incremental",
     "site:watch": "eleventy --serve",

--- a/pages/_data/domain.js
+++ b/pages/_data/domain.js
@@ -1,7 +1,0 @@
-const config = require("../../config");
-
-const defaultDomain = config.build.canonical_site_url;
-/**
- * Make a DOMAIN variable available to templates.
- */
-module.exports = process.env.DOMAIN || defaultDomain;


### PR DESCRIPTION
* Split build YML files into two processes - one for production and one for headless. This includes two different deployment buckets (deploy_production and deploy_headless) - which are needed for syncing the correct build.
* Change DOMAIN usage, allow setting domain from cross env/env variables
* Remove DOMAIN settings from pages/_data/domain.js - we were not using it, all domain rewrites go through htmlTransforms
* Update package.json with local site building scripts (for testing domain path switching)
* Include a temporary patch on the og meta path that has a logic conflict with the html rewrite patterns (results in double slash) - need too look at this more closely later on.

Note - any absolute paths will be maintained and not automatically converted to a relative path. 
If the content API has a path that would be better as relative, we can remove those paths where necessary. As we find these instances, we can document them all to make sure we know which patterns are in effect. 
* Most often, the absolute path is needed for making web-components work in different environments as well as the editor.