### PR TITLE
Pull quote CSS support

### DIFF
--- a/src/components/scrollable-card/src/behavior.js
+++ b/src/components/scrollable-card/src/behavior.js
@@ -47,11 +47,12 @@
                                       }
                                     },{
                                       // screens greater than >= 1024px
-                                      breakpoint: 1024,
+                                      breakpoint: 1080,
                                       settings: {
-                                        slidesToShow: 2,
-                                        slidesToScroll: 1,
-                                        itemWidth: 376,
+                                        
+                                        slidesToShow: 'auto',
+                                        slidesToScroll: 'auto',
+                                        itemWidth: 392,
                                         duration: 0.25
                                       }
                                     }

--- a/src/components/scrollable-card/src/css/glider-custom.scss
+++ b/src/components/scrollable-card/src/css/glider-custom.scss
@@ -1,0 +1,3 @@
+.cagov-scrollable-card-grid .glider-slide {
+    min-width: 376px;
+}

--- a/src/css/_theme-components.scss
+++ b/src/css/_theme-components.scss
@@ -2,6 +2,7 @@
 @import "../components/promotional-card/src/css/index.scss";
 @import "../components/scrollable-card/src/css/index.scss";
 @import "../components/scrollable-card/src/css/glider.min.scss";
+@import "../components/scrollable-card/src/css/glider-custom.scss";
 @import "../components/ds-card-grid/src/index.scss";
 
 @import "../components/ds-page-feedback/src/css/index.scss";

--- a/src/css/_theme-overrides.scss
+++ b/src/css/_theme-overrides.scss
@@ -96,3 +96,8 @@ blockquote {
   margin: 0 0 22px;
   border-left: 5px solid #d6d6d6;
 }
+
+figure {
+  border-color: transparent;
+  background-color: #eeefe8;
+}

--- a/src/css/_theme-overrides.scss
+++ b/src/css/_theme-overrides.scss
@@ -1,92 +1,98 @@
-
 /* PATCH CA Design System */
 .mobile-only {
-    display: none;
+  display: none;
+}
+
+@media screen and (max-width: 800px) {
+  .mobile-only {
+    display: inline;
   }
-  
-  @media screen and (max-width: 800px) {
-    .mobile-only {
-      display: inline;
-    }
-  }
-  
-  h2 {
-    margin-top: 2rem;
-    margin-bottom: 1.5rem;
-  }
-  
-  .cagov-block {
-    margin-bottom: 64px;
-  }
-  
-  @supports (width: min(250px, 100%)) {
-    .cagov-card-grid.cagov-grid,
-    .cagov-card-grid.cagov-grid .block-editor-block-list__layout {
-      grid-template-columns: repeat(auto-fit, minmax(min(286px, 100%), 1fr));
-    }
-  }
-  
+}
+
+h2 {
+  margin-top: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.cagov-block {
+  margin-bottom: 64px;
+}
+
+@supports (width: min(250px, 100%)) {
   .cagov-card-grid.cagov-grid,
-  .cagov-grid .block-editor-block-list__layout {
-    display: grid;
-    grid-gap: 1.5rem;
+  .cagov-card-grid.cagov-grid .block-editor-block-list__layout {
+    grid-template-columns: repeat(auto-fit, minmax(min(286px, 100%), 1fr));
   }
-  
-  .cagov-featured-sidebar {
-    h2 {
-      font-size: 2.135rem;
-    }
-  
-    .cagov-feature-card-body-content p {
-      font-size: 1.125rem;
-      line-height: 1.6;
-      color: #000;
-    }
-  
-    .wp-block-button__link {
-      background-color: #064e66;
-      border-radius: 5px;
-      font-weight: 700;
-      padding: 0.5rem 1rem;
-      color: #fff;
-  
-      box-shadow: none;
-      cursor: pointer;
-      display: inline-block;
-      font-size: 1.125em;
-  
-      text-align: center;
-      text-decoration: none;
-      overflow-wrap: break-word;
-      box-sizing: border-box;
-    }
+}
+
+.cagov-card-grid.cagov-grid,
+.cagov-grid .block-editor-block-list__layout {
+  display: grid;
+  grid-gap: 1.5rem;
+}
+
+.cagov-featured-sidebar {
+  h2 {
+    font-size: 2.135rem;
   }
-  
-  .external-link-icon {
-    width: 20px;
+
+  .cagov-feature-card-body-content p {
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: #000;
   }
-  
-  .pdf-link-icon {
-    font-family: "Roboto", sans-serif;
-    font-size: 0.6rem;
-    font-weight: 400;
+
+  .wp-block-button__link {
+    background-color: #064e66;
+    border-radius: 5px;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    color: #fff;
+
+    box-shadow: none;
+    cursor: pointer;
     display: inline-block;
-    outline: 1px solid;
-    outline-offset: -2px;
-    padding: 1px 4px 0px 4px;
-    position: relative;
-    left: 1px;
-    top: -3px;
-    line-height: .9rem;
-    margin-left: 4px;
-  }
-  
-  .page-feedback-footer {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: column;
+    font-size: 1.125em;
+
+    text-align: center;
+    text-decoration: none;
+    overflow-wrap: break-word;
     box-sizing: border-box;
-    max-width: var(--w-lg, 1176px);
-    margin: 0 auto;
-    padding: 16px;
   }
+}
+
+.external-link-icon {
+  width: 20px;
+}
+
+.pdf-link-icon {
+  font-family: "Roboto", sans-serif;
+  font-size: 0.6rem;
+  font-weight: 400;
+  display: inline-block;
+  outline: 1px solid;
+  outline-offset: -2px;
+  padding: 1px 4px 0px 4px;
+  position: relative;
+  left: 1px;
+  top: -3px;
+  line-height: 0.9rem;
+  margin-left: 4px;
+}
+
+.page-feedback-footer {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  box-sizing: border-box;
+  max-width: var(--w-lg, 1176px);
+  margin: 0 auto;
+  padding: 16px;
+}
+
+blockquote {
+  font-size: 1.2rem;
+  padding: 11px 22px;
+  margin: 0 0 22px;
+  border-left: 5px solid #d6d6d6;
+}

--- a/src/css/_wordpress.scss
+++ b/src/css/_wordpress.scss
@@ -63,3 +63,69 @@ figure.wp-block-post-featured-image {
     word-break: normal;
   }
 }
+
+.wp-block-media-text__media img,
+.wp-block-media-text__media video {
+  height: auto;
+  max-width: unset;
+  width: 100%;
+  vertical-align: middle;
+}
+
+.wp-block-media-text .wp-block-media-text__content {
+  direction: ltr;
+  grid-column: 2;
+  grid-row: 1;
+  padding: 0 8%;
+  word-break: break-word;
+}
+
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__content,
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__media,
+.wp-block-media-text .wp-block-media-text__content,
+.wp-block-media-text .wp-block-media-text__media {
+  align-self: center;
+}
+
+.wp-block-media-text {
+  direction: ltr;
+  display: grid;
+  grid-template-columns: 50% 1fr;
+  grid-template-rows: auto;
+}
+
+.wp-block-media-text .wp-block-media-text__content {
+  direction: ltr;
+  grid-column: 2;
+  grid-row: 1;
+  padding: 0 8%;
+  word-break: break-word;
+}
+
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__content,
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__media,
+.wp-block-media-text .wp-block-media-text__content,
+.wp-block-media-text .wp-block-media-text__media {
+  align-self: center;
+}
+
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__content,
+.wp-block-media-text.is-vertically-aligned-center .wp-block-media-text__media,
+.wp-block-media-text .wp-block-media-text__content,
+.wp-block-media-text .wp-block-media-text__media {
+  align-self: center;
+}
+
+@media (max-width: 600px) {
+  .wp-block-media-text.is-stacked-on-mobile {
+    grid-template-columns: 100% !important;
+  }
+  .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media {
+      grid-column: 1;
+      grid-row: 1;
+  }
+  .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
+    grid-column: 1;
+    grid-row: 2;
+  }
+}

--- a/src/css/_wordpress.scss
+++ b/src/css/_wordpress.scss
@@ -64,6 +64,14 @@ figure.wp-block-post-featured-image {
   }
 }
 
+.wp-block-pullquote {
+  margin: 0 0 1em;
+  padding: 3em 0;
+  text-align: center;
+  overflow-wrap: break-word;
+  box-sizing: border-box;
+}
+
 .wp-block-media-text__media img,
 .wp-block-media-text__media video {
   height: auto;
@@ -116,16 +124,36 @@ figure.wp-block-post-featured-image {
   align-self: center;
 }
 
+.wp-block-media-text .wp-block-media-text__content {
+  direction: ltr;
+  grid-column: 2;
+  grid-row: 1;
+  padding: 0 8%;
+  word-break: break-word;
+}
+
+.wp-block-pullquote p {
+  font-size: 1.75em;
+  line-height: 1.6;
+}
+
 @media (max-width: 600px) {
   .wp-block-media-text.is-stacked-on-mobile {
     grid-template-columns: 100% !important;
   }
   .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media {
-      grid-column: 1;
-      grid-row: 1;
+    grid-column: 1;
+    grid-row: 1;
   }
   .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
     grid-column: 1;
     grid-row: 2;
+  }
+  .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .wp-block-media-text.is-stacked-on-mobile {
+    grid-template-columns: 100% !important;
   }
 }


### PR DESCRIPTION
Add CSS support for blockquotes and blockquotes in wordpress media text containers.
Styles from WordPress and CAWeb style sheets brought in to accompany WP editor layouts.