### PR TITLE
Corrected page icon and favicon references. 

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -16,8 +16,8 @@
             "page_default_open_graph_image_height": 630,
             "gov_name": "CA.GOV",
             "gov_url": "https:\/\/ca.gov",
-            "favicon": "/assets/cagov_favicon.ico",
-            "page_icon": "/assets/img/cannabis_favicon_16x16.png",
+            "favicon": "/assets/cannabis_favicon_16x16.png",
+            "page_icon": "/assets/img/UNUSED.png",
             "keywords": "California, government"
         }
     },

--- a/pages/pages.11tydata.js
+++ b/pages/pages.11tydata.js
@@ -157,7 +157,8 @@ const getPageMetadata = (articleRaw) => {
 
     favicon: config.page_metadata[article.locale]?.favicon,
 
-    page_icon: config.page_metadata[article.locale]?.page_icon,
+    // UNUSED
+    // page_icon: config.page_metadata[article.locale]?.page_icon,
 
     // Title for <title> HTML tag
     page_title: getPageTitle(article),


### PR DESCRIPTION
The Problem:
We were getting a poppy favicon when we wanted a cannabis leaf.

Diagnosis:
page_icon (which was pointing to the cannabis icon) was not actually in use.
favicon (which was in use) was pointing to the poppy icon.

The Fix:
Fixed this so that page_icon is commented out / renamed for clarity, and favicon points to the desired icon (the cannabis leaf). 

Tested on Chrome, Firefox, Safari, iPhone.

