### PR TITLE
Issue #186. Added date display and styling to press releases.

### DIFF
--- a/pages/_includes/layouts/press-release.njk
+++ b/pages/_includes/layouts/press-release.njk
@@ -13,10 +13,11 @@
                         <div class="category-label">{{ category | safe }}</div>
                         <!-- Page Title-->
                         <h1 class="page-title">{{ title | safe }}</h1>
-                        <p class="page-date published">
-                            <time datetime="">
+                        <p class="published press-release-date">
+                            {{ date | safe }}
+                            {# <time datetime="Dray 14, 2022">
                                 <!-- date field -->
-                            </time>
+                            </time> #}
                         </p>
                         <div class="entry-content">
                             {{ content | safe }}

--- a/src/css/_post.scss
+++ b/src/css/_post.scss
@@ -12,3 +12,9 @@
   font-size: 1.1em;
   margin-bottom: 8px;
 }
+
+.press-release-date {
+  margin-top: 24px;
+  margin-bottom: 24px;
+  font-weight: 700;
+}


### PR DESCRIPTION
Added date display to press releases.  Can be tested by using the following relative URL

`2020/05/state-cannabis-licensing-authorities-offer-60-day-license-fee-deferrals/`

BEFORE
<img width="731" alt="CleanShot 2022-12-13 at 15 00 54" src="https://user-images.githubusercontent.com/287977/207463549-4daaba9e-076f-4bb4-a15e-2c02f78a9a3d.png">

AFTER
<img width="717" alt="CleanShot 2022-12-13 at 15 00 18" src="https://user-images.githubusercontent.com/287977/207463498-ad49b8b0-32d0-4a61-8322-a77d80247b30.png">



