### PR TITLE
Rename a workflow to reduce ambiguity

### DIFF
--- a/.github/workflows/eleventy_build_headless.yml
+++ b/.github/workflows/eleventy_build_headless.yml
@@ -1,4 +1,4 @@
-name: 11ty build Production Site
+name: 11ty build Production Site headless
 # site:  https://headless.cannabis.ca.gov
 # s3 bucket http://headless.cannabis.ca.gov.s3-website-us-west-1.amazonaws.com/
 # editor: https://api.cannabis.ca.gov


### PR DESCRIPTION
There are two workflows with the name '11ty build production site' -- I am renaming one of them '11ty build production site **headless**' so I can distinguish between the two more easily in the Actions log.