### PR TITLE
Added styling for job application steps at /about-us/work-for-dcc/ and other pages.

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -14,3 +14,134 @@
 @import "../components/event-post-list";
 
 /* STYLE FIXES AND PATCHES */
+/* step list */
+ol.steps {
+    padding-left: 0 !important;
+    margin-left: 30px !important;
+  }
+  ol.steps li {
+    list-style: none;
+    border-left: 5px solid #fec02f;
+    font-size: 1.75rem;
+    font-weight: 700;
+    position: relative;
+    padding-left: 45px;
+    line-height: 1.5;
+  }
+  ol.steps li:before {
+    content: "";
+    font-family: "Public Sans";
+    font-size: 1.75rem;
+    font-weight: 700;
+    padding: 0 13px 0 13px;
+    border: 5px solid #fec02f;
+    background-color: #fff;
+    border-radius: 50px;
+    text-align: center;
+    position: absolute;
+    left: -29px;
+    top: -5px;
+    margin-left: -1px;
+  }
+  ol.steps li span.has-black-color {
+    margin-top: 1rem;
+    padding-bottom: 1.75rem;
+    font-size: 1.125rem;
+    font-weight: 500;
+    display: block;
+  }
+  ol.steps li:first-child:before {
+    content: "1";
+    padding: 0 16px 0 16px;
+  }
+  ol.steps li:nth-child(2):before {
+    content: "2";
+  }
+  ol.steps li:nth-child(3):before {
+    content: "3";
+  }
+  ol.steps li:nth-child(4):before {
+    content: "4";
+  }
+  ol.steps li:nth-child(5):before {
+    content: "5";
+  }
+  ol.steps li:nth-child(6):before {
+    content: "6";
+  }
+  ol.steps li:nth-child(7):before {
+    content: "7";
+  }
+  ol.steps li:nth-child(8):before {
+    content: "8";
+  }
+  ol.steps li:nth-child(9):before {
+    content: "9";
+  }
+  ol.steps li:nth-child(10):before {
+    content: "10";
+    padding: 0 7px 0 7px;
+    margin-left: -1px;
+  }
+  ol.steps li:nth-child(11):before {
+    content: "11";
+    padding: 0 10px 0 10px;
+  }
+  ol.steps li:nth-child(12):before {
+    content: "12";
+    padding: 0 8px 0 8px;
+    margin-left: -1px;
+  }
+  ol.steps li:nth-child(13):before {
+    content: "13";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(14):before {
+    content: "14";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(15):before {
+    content: "15";
+    padding: 0 7px 0 8px;
+      margin-left: 3px;
+  }
+  ol.steps li:nth-child(16):before {
+    content: "16";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(17):before {
+    content: "17";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(18):before {
+    content: "18";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(19):before {
+    content: "19";
+    padding: 0 7px 0 7px;
+  }
+  ol.steps li:nth-child(20):before {
+    content: "20";
+    padding: 0 5px 0 5px;
+  }
+  ol.steps li:nth-child(21):before {
+    content: "21";
+    padding: 0 6px 0 6px;
+  }
+  ol.steps li:nth-child(22):before {
+    content: "22";
+    padding: 0 5px 0 5px;
+  }
+  ol.steps li:nth-child(23):before {
+    content: "23";
+    padding: 0 5px 0 5px;
+  }
+  ol.steps li:nth-child(24):before {
+    content: "24";
+    padding: 0 5px 0 5px;
+  }
+  ol.steps li:last-child {
+    border-left: none;
+  }
+  


### PR DESCRIPTION
Affects styling of lists on several pages (any where where ol.steps appears), which had not been using the gold-circle and line scheme that is used on the Wordpress review styling.  This adds a styling override which corrects this.

* pages/apply-for-an-equity-fee-waiver.html
* pages/banking-insurance.html
* pages/disaster-relief-programs.html
* pages/how-regulations-are-made.html
* pages/medicinal-cannabis.html
* pages/work-for-dcc.html

It looked like a generic list, needs to look like this:

<img width="694" alt="CleanShot 2023-01-23 at 13 49 59" src="https://user-images.githubusercontent.com/287977/214157776-90fd85fd-1441-4a09-afcc-9b07f98ac68c.png">
