### PR TITLE
Programmatic sitemap exclusions. 

### DIFF
--- a/pages/_data/sitemap.json
+++ b/pages/_data/sitemap.json
@@ -7,6 +7,7 @@
       "/licensees/": { "exclude": true },
       "/consumers/": { "exclude": true },
       "/applicants/": { "exclude": true },
+      "/testing-page/": { "exclude": true },
       "/about-us/public-awareness-campaigns/this-is-california-cannabis/": { "exclude": true},
       "/about-us/public-awareness-campaigns/this-is-california-cannabis/licensee-profile-abarca/": { "exclude": true},
       "/about-us/public-awareness-campaigns/this-is-california-cannabis/licensee-profile-ball/": { "exclude": true},

--- a/pages/sitemap.njk
+++ b/pages/sitemap.njk
@@ -5,7 +5,9 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for page in collections.all %}
-    {% if not sitemap.urls[page.url | url ].exclude %}
+    {% if "-MORGUE" not in page.url and 
+          "-DRAFT" not in page.url and 
+          not sitemap.urls[page.url | url ].exclude %}
       <url>
         <loc>https://cannabis.ca.gov{{ page.url | url }}</loc>
         <lastmod>{{ page.date.toISOString() }}</lastmod>


### PR DESCRIPTION
Reject all urls that contain -DRAFT or -MORGUE from showing up in the sitemap.  This makes it easier for Wes to retire old pages without outright deleting them.

Added testing-page to sitemap exclusions.
