### PR TITLE
Added media backup step to build.

### DIFF
--- a/.github/workflows/eleventy_build_main.yml
+++ b/.github/workflows/eleventy_build_main.yml
@@ -57,6 +57,8 @@ jobs:
       # jbum added exclude
       - name: Deploy to S3 (cannabis.ca.gov)
         run: aws s3 sync --follow-symlinks --delete ./docs s3://cannabis.ca.gov --exclude 'wp-content/uploads/*'
+      - name: Backup S3 Media (just the media, no deletions)
+        run: aws s3 sync s3://cannabis.ca.gov/wp-content/ s3://cannabis.ca.gov-backup/wp-content/
       # Reset the cache-control headers on static assets on production S3 bucket
       - name: Reset cache-control on fonts
         uses: prewk/s3-cp-action@v2


### PR DESCRIPTION
Since media is no longer backed up on the static-repo, this copies all media to a second bucket (without deleting anything), just to have a second copy. Normally takes just a few seconds.