### PR TITLE
Do not rewrite media urls for non-canonical urls.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -115,7 +115,7 @@ module.exports = function eleventyBuild(eleventyConfig) {
       // Replace any domain from replace list with the canonical url for the current build.
       // For this cannabis.ca.gov instance, there are multiple URL sources coming from different backend systems
       config.build.replace_urls.forEach((rootPath) => {
-        if (html !== undefined && html.includes(rootPath)) {
+        if (html !== undefined && html.includes(rootPath) && !html.includes('wp-content/uploads')) {
           html = html.replace(
             new RegExp(rootPath, "g"),
             config.build.canonical_site_url


### PR DESCRIPTION
Currently, local (dev) builds are overwriting media URLs to point to (now non-existent) media hosted at localhost.  Media only exists in one location now (the S3 bucket, accessed at the canonical URL), so Dev builds should not rewrite media urls.
This fixes that issue, so that local builds display media correctly.