### PR TITLE
Removed redundant backup step.

### DIFF
--- a/.github/workflows/eleventy_build_main.yml
+++ b/.github/workflows/eleventy_build_main.yml
@@ -57,8 +57,6 @@ jobs:
       # jbum added exclude
       - name: Deploy to S3 (cannabis.ca.gov)
         run: aws s3 sync --follow-symlinks --delete ./docs s3://cannabis.ca.gov --exclude 'wp-content/uploads/*'
-      - name: Backup S3 Media (just the media, no deletions)
-        run: aws s3 sync s3://cannabis.ca.gov/wp-content/ s3://cannabis.ca.gov-backup/wp-content/
       # Reset the cache-control headers on static assets on production S3 bucket
       - name: Reset cache-control on fonts
         uses: prewk/s3-cp-action@v2


### PR DESCRIPTION
Now that bucket versioning is enabled on the cannabis.ca.gov S3 bucket, it is no longer necessary to backup the media library to a separate S3 bucket.  Deleted and modified files will be preserved in the versioning history.  These files are also redundantly backed up on Pantheon itself.

This will save a few additional seconds of build time.