### PR TITLE
Increasing retries on Cloudfront invalidation from 2 to 6.

### DIFF
--- a/.github/workflows/eleventy_build_main.yml
+++ b/.github/workflows/eleventy_build_main.yml
@@ -91,6 +91,9 @@ jobs:
           AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} npm run deploy:redirects
 
       - name: Invalidate Cloudfront (cannabis.ca.gov)
+        env:
+           AWS_RETRY_MODE: standard
+           AWS_MAX_ATTEMPTS: 6
         run: aws cloudfront create-invalidation --distribution-id E2RLC9PDB1JLNI --paths "/*"
 
 


### PR DESCRIPTION
As documented here, we've had two build failures on Cannabis caused by failure of AWS Cloudfront invalidation, which sometimes appears overloaded. This is generally fixed by trying again. 

This patch increases the retries from 2 to 6, in an attempt to work around this problem. I used these two pages as reference. 

Setting retry on AWS:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html#cli-usage-retries-modes-adaptive

Setting environment variables in workflow:
https://docs.github.com/en/actions/learn-github-actions/variables

According to the AWS docs, a backoff delay is added to each successive retry, capping at 20 seconds. This should help if the cloudfront congestion is relatively short term.