### PR TITLE
Updated GA initialization to use GA4 IDs in accordance state policy.

### DIFF
--- a/src/js/analytics/google-analytics.js
+++ b/src/js/analytics/google-analytics.js
@@ -1,7 +1,9 @@
+// Based on template provided here:
+// https://webstandards.ca.gov/add-analytics-to-your-site/
 (function () {
   const ga = document.createElement("script");
   ga.async = true;
-  ga.src = "https://www.googletagmanager.com/gtag/js?id=UA-31125811-39";
+  ga.src = "https://www.googletagmanager.com/gtag/js?id=G-75V2BNQ3DR";
   const s = document.getElementsByTagName("script")[0];
   s.parentNode.insertBefore(ga, s);
 })();
@@ -11,5 +13,6 @@ window.gtag = function () {
   dataLayer.push(arguments);
 };
 gtag("js", new Date());
-gtag("config", "UA-31125811-39");
-gtag("config", "UA-3419582-2");
+gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
+gtag("config", "G-75V2BNQ3DR"); // DCC (Cannabis) GA4 measurement ID
+


### PR DESCRIPTION
This modifies the current Google Analytics IDs to the newly requisitioned Google Analytics 4 IDs.
```
gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
gtag("config", "G-75V2BNQ3DR"); // DCC (Cannabis) GA4 measurement ID
```

The code was already essentially the same as the 'Custom Template Setup' described at https://webstandards.ca.gov/add-analytics-to-your-site/, so the only changed needed was to change the IDs.

